### PR TITLE
Add shaders loading function and add line shader to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,3 +16,4 @@ include fury/_version.py
 include fury/data/files/*.json
 include fury/data/files/*.log.gz
 include fury/data/files/*.pkl
+include fury/shaders/*.geom

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -4,6 +4,7 @@ import numpy as np
 import vtk
 from vtk.util import numpy_support
 
+import fury.shaders
 from fury.colormap import colormap_lookup_table, create_colormap
 from fury.utils import (lines_to_vtk_polydata, set_input, apply_affine,
                         numpy_to_vtk_points, numpy_to_vtk_colors,
@@ -522,10 +523,7 @@ def line(lines, colors=None, opacity=1, linewidth=1,
     poly_mapper.Update()
 
     if depth_cue:
-        geom_shader_file = open("fury/shaders/line.geom", "r")
-        geom_shader_code = geom_shader_file.read()
-
-        poly_mapper.SetGeometryShaderCode(geom_shader_code)
+        poly_mapper.SetGeometryShaderCode(fury.shaders.load("line.geom"))
 
         @vtk.calldata_type(vtk.VTK_OBJECT)
         def vtkShaderCallback(caller, event, calldata=None):

--- a/fury/shaders/__init__.py
+++ b/fury/shaders/__init__.py
@@ -1,0 +1,12 @@
+"""Read shader files."""
+
+from os.path import join as pjoin, dirname
+
+SHADERS_DIR = pjoin(dirname(__file__))
+
+def load(filename):
+    with open(pjoin(SHADERS_DIR, filename)) as shader_file:
+        return shader_file.read()
+
+
+__all__ = ['SHADERS_DIR', 'load']

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.version_info < (2, 7):
 
                python3 --version
 
-               This may be due to an out-of-date pip. 
+               This may be due to an out-of-date pip.
                Make sure you have pip >= 9.0.1.
                Upgrade pip like so:
 
@@ -55,6 +55,7 @@ setup(
             "fury/data/files/*.json",
             "fury/data/files/*.log.gz",
             "fury/data/files/*.pkl"
+            "fury/shaders/*.geom"
             ]
         },
     install_requires=['numpy>=1.7.1',


### PR DESCRIPTION
At the moment, shader files are not being installed along with fury. Also, the relative path used in `actor.py` breaks when the current working folder is not the root of `fury` (e.g. when making the docs).